### PR TITLE
Update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,15 @@ python:
 env:
 - DJANGO="django>=1.11.0,<1.12.0"
 - DJANGO="django>=2.0,<2.1"
+- DJANGO="django>=2.1,<2.2"
 matrix:
   exclude:
   - python: '2.7'
     env: DJANGO="django>=2.0,<2.1"
+  - python: '2.7'
+    env: DJANGO="django>=2.1,<2.2"
+  - python: '3.4'
+    env: DJANGO="django>=2.1,<2.2"
 before_install:
 - pip install codecov
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,11 @@ sudo: false
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
+- '3.5'
+- '3.6'
 env:
-- DJANGO="django>=1.7.0,<1.8.0 djangorestframework<3.4"
-- DJANGO="django>=1.8.0,<1.9.0"
-- DJANGO="django>=1.9.0,<1.10.0"
-matrix:
-  exclude:
-  - python: '3.3'
-    env: DJANGO="django>=1.9.0,<1.10.0"
+- DJANGO="django>=1.11.0,<1.12.0"
 before_install:
 - pip install codecov
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ python:
 - '3.6'
 env:
 - DJANGO="django>=1.11.0,<1.12.0"
+- DJANGO="django>=2.0,<2.1"
+matrix:
+  exclude:
+  - python: '2.7'
+    env: DJANGO="django>=2.0,<2.1"
 before_install:
 - pip install codecov
 install:

--- a/parler_rest/fields.py
+++ b/parler_rest/fields.py
@@ -3,6 +3,7 @@
 Custom serializer fields for nested translations.
 """
 from __future__ import unicode_literals
+from collections import OrderedDict
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 
@@ -12,11 +13,6 @@ from parler.models import TranslatableModel, TranslatedFieldsModel
 from parler.utils.context import switch_language
 
 from parler_rest.utils import create_translated_fields_serializer
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
 
 
 class TranslatedFieldsField(serializers.Field):

--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,13 @@ setup(
 
     install_requires=[
         'django-parler>=1.2',
-        'djangorestframework>=3.0',
+        'djangorestframework>=3.5',
     ],
     requires=[
-        'Django (>=1.4.2)',
+        'Django (>=1.11)',
     ],
     tests_require=[
-        'django>=1.8',
+        'django>=1.11',
         'pytest==2.7.1',
         'pytest-django==2.8.0',
         'pytest-cov==1.8.1',
@@ -81,11 +81,10 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        # 'Programming Language :: Python :: 3.2',
-        # 'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/testproj/migrations/0001_initial.py
+++ b/testproj/migrations/0001_initial.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
                 ('language_code', models.CharField(max_length=15, verbose_name='Language', db_index=True)),
                 ('name', models.CharField(max_length=200, verbose_name='name')),
                 ('url', models.URLField(verbose_name='webpage', blank=True)),
-                ('master', models.ForeignKey(related_name='translations', editable=False, to='testproj.Country', null=True)),
+                ('master', models.ForeignKey(related_name='translations', editable=False, to='testproj.Country', null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'managed': True,

--- a/testproj/settings.py
+++ b/testproj/settings.py
@@ -29,18 +29,14 @@ SECRET_KEY = '87$noc%^65_5qgg_ngcsdqf&x$2663ch+7ke(5za1vtp!x!lgx'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-if django.VERSION >= (1, 8):
-    TEMPLATES = [
-        {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'OPTIONS': {
-                'debug': True,
-            },
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'OPTIONS': {
+            'debug': True,
         },
-    ]
-
-else:
-    TEMPLATE_DEBUG = True
+    },
+]
 
 ALLOWED_HOSTS = []
 
@@ -58,7 +54,7 @@ INSTALLED_APPS = [
     'testproj',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist=
     py27-django{111},
     py34-django{111,20},
-    py35-django{111,20},
-    py36-django{111,20},
+    py35-django{111,20,21},
+    py36-django{111,20,21},
     coverage,
     docs,
 
@@ -14,6 +14,7 @@ deps =
     djangorestframework >= 3.5
     django111: Django >= 1.11,<1.12
     django20: Django >= 2.0,<2.1
+    django21: Django >= 2.1,<2.2
 commands=
     python runtests.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist=
     py27-django{111},
-    py34-django{111},
-    py35-django{111},
-    py36-django{111},
+    py34-django{111,20},
+    py35-django{111,20},
+    py36-django{111,20},
     coverage,
     docs,
 
@@ -13,6 +13,7 @@ deps =
     django-parler
     djangorestframework >= 3.5
     django111: Django >= 1.11,<1.12
+    django20: Django >= 2.0,<2.1
 commands=
     python runtests.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,38 +1,33 @@
 [tox]
 envlist=
-    py27-django{17,18,19},
-    py32-django{17,18},
-    py33-django{17,18},
-    py34-django{17,18,19},
-    # py33-django-dev,
-    converage,
+    py27-django{111},
+    py34-django{111},
+    py35-django{111},
+    py36-django{111},
+    coverage,
     docs,
 
 [testenv]
 deps =
     six
     django-parler
-    djangorestframework >= 3.1
-    django17: Django >= 1.7,<1.8
-    django17: djangorestframework >=3.1,<3.4
-    django18: Django >= 1.8,<1.9
-    django19: Django >= 1.9,<1.10
-    django-dev: https://github.com/django/django/tarball/master
+    djangorestframework >= 3.5
+    django111: Django >= 1.11,<1.12
 commands=
     python runtests.py
 
 [testenv:docs]
 changedir=docs
 deps=
-  django==1.9
+  django==1.11
   Sphinx
 commands=sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:coverage]
-basepython=python3.3
+basepython=python3.6
 deps=
-    django==1.8.0
-    coverage==3.7.1
+    django==1.11.15
+    coverage==4.5.1
 commands=
     coverage erase
     coverage run --source=parler_rest runtests.py


### PR DESCRIPTION
Removes old, unsupported, Django versions from the test matrix, and replaces them with currently-supported Python/Django combinations. I haven't added Python 3.7, as it's not supported on Travis CI at present.

This is perhaps slightly presumptuous of me, but brings this project into line with `django-parler`.