### PR TITLE
Allow for defining translatable fields loosly on the model 

### DIFF
--- a/testproj/serializers.py
+++ b/testproj/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
-from parler_rest.serializers import TranslatableModelSerializer, TranslatedFieldsField, TranslatedField
+from parler_rest.serializers import TranslatableModelSerializer, TranslatedFieldsField, TranslatedField, \
+    TranslatableFlatModelSerializer
 
 from .models import Country, Picture
 
@@ -65,3 +66,47 @@ class PictureCaptionSerializer(TranslatableModelSerializer):
     class Meta:
         model = Picture
         fields = ('image_nr', 'caption')
+
+
+class FlatCountryTranslatedSerializer(TranslatableFlatModelSerializer):
+    """
+    A serializer with a flat structure returning a single language for the translations
+    """
+
+    class Meta:
+        model = Country
+        fields = ('pk', 'country_code', 'language_code', 'name', 'url')
+
+
+class FlatCountryExplicitLangTranslatedSerializer(TranslatableFlatModelSerializer):
+    """
+    A serializer where the possible language choice for the language_code field is explicit assigned
+    """
+    LANGUAGE_CHOICES = (
+        ('en', 'english'),
+        ('es', 'spanish'),
+        ('fr', 'french'),
+    )
+    language_code = serializers.ChoiceField(choices=LANGUAGE_CHOICES)
+
+    class Meta:
+        model = Country
+        fields = ('pk', 'country_code', 'language_code', 'name', 'url')
+
+
+class FlatCountryNoLanguageCodeTranslatedSerializer(TranslatableFlatModelSerializer):
+    """
+    A serializer without a language_code field declared
+    """
+
+    class Meta:
+        model = Country
+        fields = ('pk', 'country_code', 'name', 'url')
+
+
+class FlatContinentCountriesTranslatedSerializer(serializers.Serializer):
+    """
+    A flat serializer with a nested translation serializer
+    """
+    continent = serializers.CharField()
+    countries = FlatCountryTranslatedSerializer(many=True)


### PR DESCRIPTION
### Summary
I changed the `TranslatableModelSerializer` to allow for translatable fields to be defined directly on the serializer. This way, you can create flat models which return the translated values for a single language and allow for updating a model in a single language. The language for saving an object is derived from the `LanguageCode` field when present. Else it will use the default language detection of Django to determine the language for saving.

### Reason / Use case
I was using django-hvad, which comes with a serializer which outputs the object in a flat structure as a single translation. I wanted to migrate my API from django-hvad to django-parler without changing the API structure.

### Notes
I started out creating a separate `FlatTranslatableModelSerialzer`. When it worked I saw that the logic could be combined into the existing `TranslatableModelSerializer` without impacting the existing logic. I also didn't like the name of my new model serializer. 
Currently, the serializer either pop's the translations field when finding it or it starts popping fields which are translatable. Another take to this would have been to enable/disable the flat structure with a param in __init__.

I also started out with creating a special `LanguageCode` field, but it seems that the auto-generated field by DRF had all functionality/validation needed. You can easily override the default LanguageCode field using the standard ChoiceField, i.e.: `serializers.ChoiceField(choices=settings.LANGUAGES, required=False)`
