### PR TITLE
Replace deprecated ugettext_lazy with ugettext_lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First configure a model, following the [django-parler documentation](https://dja
 
 ```python
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from parler.models import TranslatableModel, TranslatedFields
 

--- a/parler_rest/fields.py
+++ b/parler_rest/fields.py
@@ -5,7 +5,7 @@ Custom serializer fields for nested translations.
 from __future__ import unicode_literals
 from collections import OrderedDict
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 from rest_framework.fields import SkipField

--- a/testproj/models.py
+++ b/testproj/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from parler.models import TranslatableModel, TranslatedFields, TranslatedField, TranslatedFieldsModel
 

--- a/testproj/settings.py
+++ b/testproj/settings.py
@@ -13,7 +13,7 @@ from __future__ import unicode_literals
 import os.path
 
 import django
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)


### PR DESCRIPTION
The `django.utils.translation.ugettext_lazy` function has been deprecated in favor of `django.utils.translation.gettext_lazy`, starting Django 3.0:

https://docs.djangoproject.com/en/3.0/releases/3.0/#id3

Consequently, using `django-parler-rest` in projects with Django 3.0+ gives deprecation warnings:

```
parler_rest/fields.py:23
  /<redacted>/parler_rest/fields.py:23: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    'invalid': _("Input is not a valid dict"),

parler_rest/fields.py:24
  /<redacted>/parler_rest/fields.py:24: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    'empty': _("This field may not be empty.")
```

This PR changes all `ugettext_lazy` imports with `gettext_lazy`, which gets rid of the deprecation warnings with Django 3.0+ and thus also fixes #32.