### PR TITLE
exclude translated fields in serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ class CountrySerializer(TranslatableModelSerializer):
 **Note:** The `TranslatedFieldsField` can only be used in a serializer that inherits from
 `TranslatableModelSerializer`.
 
+To exclude translated fields you can use the ```exclude_fields``` parameter of TranslatedFieldsField.
+
+```
+class CountrySerializer(TranslatableModelSerializer):
+    translations = TranslatedFieldsField(shared_model=Country, exclude_fields=['url'])
+
+    class Meta:
+        model = Country
+        fields = ('id', 'country_code', 'translations')
+```
+
 
 This will expose the fields as a separate dictionary in the JSON output:
 

--- a/parler_rest/fields.py
+++ b/parler_rest/fields.py
@@ -28,6 +28,7 @@ class TranslatedFieldsField(serializers.Field):
         """
         self.serializer_class = kwargs.pop('serializer_class', None)
         self.shared_model = kwargs.pop('shared_model', None)
+        self.exclude_fields = kwargs.pop('exclude_fields', [])
 
         self.allow_empty = kwargs.pop('allow_empty', False)
         super(TranslatedFieldsField, self).__init__(*args, **kwargs)
@@ -108,7 +109,13 @@ class TranslatedFieldsField(serializers.Field):
 
         # Split into a dictionary per language
         result = OrderedDict()
+
         for translation in translations:
+            if self.exclude_fields:
+                for ex in self.exclude_fields:
+                    if  serializer.fields.get(ex):
+                        del serializer.fields[ex]
+
             result[translation.language_code] = serializer.to_representation(translation)
 
         return result


### PR DESCRIPTION
Hi,
I was missing the ability to exclude translated fields in the serializer and that's what this tiny patch is all about.
Best,
Basti
